### PR TITLE
Add missing file from scaffolding files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,7 @@ web.config
 
 # Remove me after sous install
 README.txt
-development.services.yml
+web/sites/development.services.yml
 example.settings.local.php
 example.sites.php
 default.services.yml

--- a/assets/scaffold/files/development.services.yml
+++ b/assets/scaffold/files/development.services.yml
@@ -1,0 +1,13 @@
+# Local development services.
+#
+# To activate this feature, follow the instructions at the top of the
+# 'example.settings.local.php' file, which sits next to this file.
+parameters:
+  http.response.debug_cacheability_headers: true
+  twig.config:
+    debug: true
+    auto_reload: true
+    cache: false
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory


### PR DESCRIPTION
We are getting an error that development.services.yml is missing, it is called in a composer update hook.

Fix the .gitignore and add the missing file.